### PR TITLE
#25 Added logic for filtering external permalinks.

### DIFF
--- a/src/Tarosky/Sitemap/Provider/AttachmentSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/AttachmentSitemapProvider.php
@@ -81,6 +81,9 @@ SQL;
 		}
 		$urls = [];
 		foreach ( $results as $row ) {
+			if ( $this->is_external_permalink( $row->ID ) ) {
+				continue;
+			}
 			$urls[] = [
 				'link'    => get_permalink( $row ),
 				'lastmod' => $this->get_last_mod( $row->post_modified ),

--- a/src/Tarosky/Sitemap/Provider/NewsSitemapIndexProvider.php
+++ b/src/Tarosky/Sitemap/Provider/NewsSitemapIndexProvider.php
@@ -33,13 +33,17 @@ class NewsSitemapIndexProvider extends SitemapIndexProvider {
 	 * @return string[]
 	 */
 	protected function get_urls() {
-		$query    = new \WP_Query( $this->news_query_args( 'index', [
+		$query = new \WP_Query( $this->news_query_args( 'index', [
 			'posts_per_page' => 1,
 			'fields'         => 'ids',
 		] ) );
-		$total    = $query->found_posts;
-		$per_page = $this->default_news_per_page();
-		$urls     = [];
+		// Filter out external permalinks
+		$valid_post_ids = array_filter( $query->posts, function ( $post_id ) {
+			return ! $this->is_external_permalink( get_post( $post_id ) );
+		} );
+		$total          = count( $valid_post_ids );
+		$per_page       = $this->default_news_per_page();
+		$urls           = [];
 		for ( $i = 1; $i <= ceil( $total / $per_page ); $i++ ) {
 			$urls[] = home_url( sprintf( 'sitemap_news_%d.xml', $i ) );
 		}

--- a/src/Tarosky/Sitemap/Provider/NewsSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/NewsSitemapProvider.php
@@ -59,6 +59,9 @@ class NewsSitemapProvider extends SitemapProvider {
 		] ) );
 		$urls  = [];
 		foreach ( $query->posts as $post ) {
+			if ( $this->is_external_permalink( $post->ID ) ) {
+				continue;
+			}
 			$urls[] = [
 				'link'    => get_permalink( $post ),
 				'lastmod' => $this->get_last_mod( $post->post_modified ),

--- a/src/Tarosky/Sitemap/Provider/PostSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/PostSitemapProvider.php
@@ -116,6 +116,9 @@ SQL;
 		}
 		$urls = [];
 		foreach ( $results as $post ) {
+			if ( $this->is_external_permalink( $post->ID ) ) {
+				continue;
+			}
 			$urls[] = [
 				'link'    => get_permalink( $post ),
 				'lastmod' => $this->get_last_mod( $post->post_modified ),


### PR DESCRIPTION
- `QueryArgsHelper.php` に `is_external_permalink()` 関数を追加しました。
- すべてのサイトマップに対する `get_urls()` に、外部パーマリンクを除外するロジックを追加しました。

外部パーマリンクは別のウェブサイトを指しているため、完全にフィルタリングするのが最も理にかなっていると考えました。したがって、これらのリンクは当サイトのサイトマップに含めるべきではないと思います。