### PR TITLE
修正: lastmodの取得方法を改善

### DIFF
--- a/src/Tarosky/Sitemap/Provider/AttachmentSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/AttachmentSitemapProvider.php
@@ -83,7 +83,7 @@ SQL;
 		foreach ( $results as $row ) {
 			$urls[] = [
 				'link'    => get_permalink( $row ),
-				'lastmod' => $this->get_last_mod( $row->post_modified ),
+				'lastmod' => $this->get_last_mod( $row->post_modified, $row->post_date ),
 				'images'  => [
 					wp_get_attachment_image_url( $row->ID, 'full' ),
 				],

--- a/src/Tarosky/Sitemap/Provider/NewsSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/NewsSitemapProvider.php
@@ -61,7 +61,7 @@ class NewsSitemapProvider extends SitemapProvider {
 		foreach ( $query->posts as $post ) {
 			$urls[] = [
 				'link'    => get_permalink( $post ),
-				'lastmod' => $this->get_last_mod( $post->post_modified ),
+				'lastmod' => $this->get_last_mod( $post->post_modified, $post->post_date ),
 				'title'   => get_the_title( $post ),
 				'date'    => get_the_time( 'Y-m-d', $post ),
 			];

--- a/src/Tarosky/Sitemap/Provider/PostSitemapProvider.php
+++ b/src/Tarosky/Sitemap/Provider/PostSitemapProvider.php
@@ -121,7 +121,7 @@ class PostSitemapProvider extends SitemapProvider {
 		foreach ( $results as $post ) {
 			$urls[] = [
 				'link'    => get_permalink( $post ),
-				'lastmod' => $this->get_last_mod( $post->post_modified ),
+				'lastmod' => $this->get_last_mod( $post->post_modified, $post->post_date ),
 				'images'  => $images[ $post->ID ] ?? [],
 			];
 		}

--- a/src/Tarosky/Sitemap/Utility/QueryArgsHelper.php
+++ b/src/Tarosky/Sitemap/Utility/QueryArgsHelper.php
@@ -63,12 +63,22 @@ trait QueryArgsHelper {
 	}
 
 	/**
-	 * Get lastmod.
+	 * Get lastmod. Returns the later of post_modified and post_date in W3C format.
 	 *
-	 * @return string
+	 * When a scheduled post is published via wp_publish_post(), post_modified is not
+	 * updated. Passing post_date ensures lastmod is never older than publication_date.
+	 *
+	 * @param string      $post_modified MySQL datetime string (local time).
+	 * @param string|null $post_date     MySQL datetime string (local time). When given
+	 *                                   and newer than $post_modified, used instead.
+	 * @return string W3C-formatted datetime string.
 	 */
-	protected function get_last_mod( $post_date ) {
-		return mysql2date( \DateTime::W3C, $post_date );
+	protected function get_last_mod( string $post_modified, ?string $post_date = null ) {
+		$base = $post_modified;
+		if ( ! empty( $post_date ) && strtotime( $post_date ) > strtotime( $post_modified ) ) {
+			$base = $post_date;
+		}
+		return mysql2date( \DateTime::W3C, $base );
 	}
 
 	/**

--- a/src/Tarosky/Sitemap/Utility/QueryArgsHelper.php
+++ b/src/Tarosky/Sitemap/Utility/QueryArgsHelper.php
@@ -75,7 +75,7 @@ trait QueryArgsHelper {
 	 */
 	protected function get_last_mod( string $post_modified, ?string $post_date = null ) {
 		$base = $post_modified;
-		if ( ! empty( $post_date ) && strtotime( $post_date ) > strtotime( $post_modified ) ) {
+		if ( ! empty( $post_date ) && $post_date > $post_modified ) {
 			$base = $post_date;
 		}
 		return mysql2date( \DateTime::W3C, $base );

--- a/tests/SitemapLastmodTest.php
+++ b/tests/SitemapLastmodTest.php
@@ -15,7 +15,7 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 	// Unit tests: get_last_mod()
 	// -----------------------------------------------------------------------
 
-	private function call_get_last_mod( string $post_modified, string $post_date = null ): string {
+	private function call_get_last_mod( string $post_modified, ?string $post_date = null ): string {
 		$provider = NewsSitemapProvider::get_instance();
 		$method   = new ReflectionMethod( $provider, 'get_last_mod' );
 		$method->setAccessible( true );
@@ -104,9 +104,9 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 		] );
 
 		$now = current_time( 'mysql' );
-		$old = gmdate( 'Y-m-d H:i:s', strtotime( '-6 days', current_time( 'timestamp' ) ) );
+		$old = date( 'Y-m-d H:i:s', strtotime( '-6 days', current_time( 'timestamp' ) ) );
 
-		$wpdb->update(
+		$updated = $wpdb->update(
 			$wpdb->posts,
 			[
 				'post_date'          => $now,
@@ -116,6 +116,7 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 			],
 			[ 'ID' => $post_id ]
 		);
+		$this->assertSame( 1, $updated, 'failed to seed scheduled-then-published post' );
 		clean_post_cache( $post_id );
 
 		return $post_id;
@@ -124,7 +125,8 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 	public function test_news_sitemap_lastmod_not_older_than_publication_date() {
 		update_option( 'tsmap_news_post_types', [ 'post' ] );
 
-		$post_id = $this->create_scheduled_then_published_post();
+		$post_id   = $this->create_scheduled_then_published_post();
+		$permalink = get_permalink( $post_id );
 
 		$provider = NewsSitemapProvider::get_instance();
 
@@ -133,23 +135,29 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 
 		$found = false;
 		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
+			$loc = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->loc;
+			if ( $loc !== $permalink ) {
+				continue;
+			}
+
 			$lastmod  = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
 			$news     = $url->children( 'http://www.google.com/schemas/sitemap-news/0.9' );
 			$pub_date = isset( $news->news->publication_date ) ? (string) $news->news->publication_date : '';
 
-			if ( empty( $lastmod ) || empty( $pub_date ) ) {
-				continue;
-			}
+			$this->assertNotEmpty( $lastmod, '<lastmod> が出力されていること' );
+			$this->assertNotEmpty( $pub_date, '<news:publication_date> が出力されていること' );
 
+			$pub_ts     = ( new DateTimeImmutable( $pub_date, wp_timezone() ) )->getTimestamp();
+			$lastmod_ts = ( new DateTimeImmutable( $lastmod ) )->getTimestamp();
 			$this->assertGreaterThanOrEqual(
-				strtotime( $pub_date ),
-				strtotime( $lastmod ),
+				$pub_ts,
+				$lastmod_ts,
 				"<lastmod>({$lastmod}) は <news:publication_date>({$pub_date}) 以上であること"
 			);
 			$found = true;
 		}
 
-		$this->assertTrue( $found, 'ニュースサイトマップに URL が1件以上含まれること' );
+		$this->assertTrue( $found, "ニュースサイトマップに対象投稿({$permalink})が含まれること" );
 
 		delete_option( 'tsmap_news_post_types' );
 		wp_delete_post( $post_id, true );
@@ -158,12 +166,14 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 	public function test_post_sitemap_lastmod_not_older_than_post_date() {
 		update_option( 'tsmap_post_types', [ 'post' ] );
 
-		$post_id = $this->create_scheduled_then_published_post();
-		$post    = get_post( $post_id );
+		$post_id   = $this->create_scheduled_then_published_post();
+		$post      = get_post( $post_id );
+		$permalink = get_permalink( $post_id );
 
 		// PostSitemapProvider の get_urls() は year/monthnum query var を使う
-		set_query_var( 'year', (int) date( 'Y', strtotime( $post->post_date ) ) );
-		set_query_var( 'monthnum', (int) date( 'm', strtotime( $post->post_date ) ) );
+		$post_date_local = new DateTimeImmutable( $post->post_date, wp_timezone() );
+		set_query_var( 'year', (int) $post_date_local->format( 'Y' ) );
+		set_query_var( 'monthnum', (int) $post_date_local->format( 'm' ) );
 		set_query_var( 'paged', 1 );
 
 		$provider = PostSitemapProvider::get_instance();
@@ -173,22 +183,26 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 
 		$found = false;
 		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
-			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
-			if ( empty( $lastmod ) ) {
+			$loc = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->loc;
+			if ( $loc !== $permalink ) {
 				continue;
 			}
 
+			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
+			$this->assertNotEmpty( $lastmod, '<lastmod> が出力されていること' );
+
 			// lastmod は post_date 以上であること
-			$post_date_ts = strtotime( $post->post_date );
+			$post_date_ts = $post_date_local->getTimestamp();
+			$lastmod_ts   = ( new DateTimeImmutable( $lastmod ) )->getTimestamp();
 			$this->assertGreaterThanOrEqual(
 				$post_date_ts,
-				strtotime( $lastmod ),
+				$lastmod_ts,
 				"<lastmod>({$lastmod}) は post_date({$post->post_date}) 以上であること"
 			);
 			$found = true;
 		}
 
-		$this->assertTrue( $found, 'ポストサイトマップに URL が1件以上含まれること' );
+		$this->assertTrue( $found, "ポストサイトマップに対象投稿({$permalink})が含まれること" );
 
 		delete_option( 'tsmap_post_types' );
 		wp_delete_post( $post_id, true );
@@ -206,8 +220,8 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 		// post_modified を post_date より1時間後にする
 		global $wpdb;
 		$post    = get_post( $post_id );
-		$later   = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_date ) + 3600 );
-		$wpdb->update(
+		$later   = date( 'Y-m-d H:i:s', strtotime( $post->post_date ) + 3600 );
+		$updated = $wpdb->update(
 			$wpdb->posts,
 			[
 				'post_modified'     => $later,
@@ -215,7 +229,10 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 			],
 			[ 'ID' => $post_id ]
 		);
+		$this->assertSame( 1, $updated, 'failed to update post_modified' );
 		clean_post_cache( $post_id );
+
+		$permalink = get_permalink( $post_id );
 
 		$provider = NewsSitemapProvider::get_instance();
 		$xml      = $this->render_url_items( $provider );
@@ -223,20 +240,26 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 
 		$found = false;
 		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
-			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
-			if ( empty( $lastmod ) ) {
+			$loc = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->loc;
+			if ( $loc !== $permalink ) {
 				continue;
 			}
+
+			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
+			$this->assertNotEmpty( $lastmod, '<lastmod> が出力されていること' );
+
 			// post_modified ベース (= $later) が使われていることを確認
+			$post_date_ts = ( new DateTimeImmutable( $post->post_date, wp_timezone() ) )->getTimestamp();
+			$lastmod_ts   = ( new DateTimeImmutable( $lastmod ) )->getTimestamp();
 			$this->assertGreaterThanOrEqual(
-				strtotime( $post->post_date ),
-				strtotime( $lastmod ),
+				$post_date_ts,
+				$lastmod_ts,
 				"<lastmod>({$lastmod}) は post_date({$post->post_date}) 以上であること"
 			);
 			$found = true;
 		}
 
-		$this->assertTrue( $found, 'ニュースサイトマップに URL が1件以上含まれること' );
+		$this->assertTrue( $found, "ニュースサイトマップに対象投稿({$permalink})が含まれること" );
 
 		delete_option( 'tsmap_news_post_types' );
 		wp_delete_post( $post_id, true );

--- a/tests/SitemapLastmodTest.php
+++ b/tests/SitemapLastmodTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use Tarosky\Sitemap\Provider\NewsSitemapProvider;
+use Tarosky\Sitemap\Provider\PostSitemapProvider;
+
+/**
+ * Tests for lastmod output in sitemaps.
+ *
+ * Covers the scenario where a scheduled post has post_modified < post_date
+ * (wp_publish_post() only updates post_status, not post_modified).
+ */
+class SitemapLastmodTest extends WP_UnitTestCase {
+
+	// -----------------------------------------------------------------------
+	// Unit tests: get_last_mod()
+	// -----------------------------------------------------------------------
+
+	private function call_get_last_mod( string $post_modified, string $post_date = null ): string {
+		$provider = NewsSitemapProvider::get_instance();
+		$method   = new ReflectionMethod( $provider, 'get_last_mod' );
+		$method->setAccessible( true );
+		if ( $post_date === null ) {
+			return $method->invoke( $provider, $post_modified );
+		}
+		return $method->invoke( $provider, $post_modified, $post_date );
+	}
+
+	public function test_get_last_mod_uses_post_modified_when_newer() {
+		$modified = '2026-05-20 10:00:00';
+		$date     = '2026-05-14 08:00:00';
+		$result   = $this->call_get_last_mod( $modified, $date );
+		$this->assertStringContainsString( '2026-05-20', $result );
+	}
+
+	public function test_get_last_mod_uses_post_date_when_newer() {
+		$modified = '2026-05-14 08:00:00';
+		$date     = '2026-05-20 09:00:00';
+		$result   = $this->call_get_last_mod( $modified, $date );
+		$this->assertStringContainsString( '2026-05-20', $result );
+	}
+
+	public function test_get_last_mod_with_equal_dates() {
+		$dt     = '2026-05-20 08:00:00';
+		$result = $this->call_get_last_mod( $dt, $dt );
+		$this->assertStringContainsString( '2026-05-20', $result );
+	}
+
+	public function test_get_last_mod_without_post_date_uses_post_modified() {
+		$modified = '2026-05-14 08:00:00';
+		$result   = $this->call_get_last_mod( $modified );
+		$this->assertStringContainsString( '2026-05-14', $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// Integration tests: XML output
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Collect do_item() output for each URL from get_urls() and wrap in urlset.
+	 *
+	 * @param object $provider SitemapProvider instance.
+	 * @return string Complete XML string with urlset wrapper.
+	 */
+	private function render_url_items( $provider ): string {
+		$get_urls = new ReflectionMethod( $provider, 'get_urls' );
+		$get_urls->setAccessible( true );
+		$urls = $get_urls->invoke( $provider );
+
+		$items = '';
+		foreach ( $urls as $url ) {
+			ob_start();
+			echo '<url>';
+			$provider->do_item( $url );
+			echo '</url>';
+			$items .= ob_get_clean();
+		}
+
+		return '<urlset'
+			. ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+			. ' xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"'
+			. ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'
+			. '>'
+			. $items
+			. '</urlset>';
+	}
+
+	private function parse_sitemap_xml( string $xml ): SimpleXMLElement {
+		$sxe = new SimpleXMLElement( $xml );
+		$sxe->registerXPathNamespace( 's', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
+		$sxe->registerXPathNamespace( 'news', 'http://www.google.com/schemas/sitemap-news/0.9' );
+		return $sxe;
+	}
+
+	/**
+	 * Creates a post that mimics a scheduled-then-published post:
+	 * post_date = recently (within 48h), post_modified = 6 days ago.
+	 */
+	private function create_scheduled_then_published_post(): int {
+		global $wpdb;
+
+		$post_id = self::factory()->post->create( [
+			'post_status' => 'publish',
+			'post_title'  => 'Scheduled post',
+		] );
+
+		$now = current_time( 'mysql' );
+		$old = gmdate( 'Y-m-d H:i:s', strtotime( '-6 days', current_time( 'timestamp' ) ) );
+
+		$wpdb->update(
+			$wpdb->posts,
+			[
+				'post_date'          => $now,
+				'post_date_gmt'      => get_gmt_from_date( $now ),
+				'post_modified'      => $old,
+				'post_modified_gmt'  => get_gmt_from_date( $old ),
+			],
+			[ 'ID' => $post_id ]
+		);
+		clean_post_cache( $post_id );
+
+		return $post_id;
+	}
+
+	public function test_news_sitemap_lastmod_not_older_than_publication_date() {
+		update_option( 'tsmap_news_post_types', [ 'post' ] );
+
+		$post_id = $this->create_scheduled_then_published_post();
+
+		$provider = NewsSitemapProvider::get_instance();
+
+		$xml = $this->render_url_items( $provider );
+		$sxe = $this->parse_sitemap_xml( $xml );
+
+		$found = false;
+		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
+			$lastmod  = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
+			$news     = $url->children( 'http://www.google.com/schemas/sitemap-news/0.9' );
+			$pub_date = isset( $news->news->publication_date ) ? (string) $news->news->publication_date : '';
+
+			if ( empty( $lastmod ) || empty( $pub_date ) ) {
+				continue;
+			}
+
+			$this->assertGreaterThanOrEqual(
+				strtotime( $pub_date ),
+				strtotime( $lastmod ),
+				"<lastmod>({$lastmod}) は <news:publication_date>({$pub_date}) 以上であること"
+			);
+			$found = true;
+		}
+
+		$this->assertTrue( $found, 'ニュースサイトマップに URL が1件以上含まれること' );
+
+		delete_option( 'tsmap_news_post_types' );
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_post_sitemap_lastmod_not_older_than_post_date() {
+		update_option( 'tsmap_post_types', [ 'post' ] );
+
+		$post_id = $this->create_scheduled_then_published_post();
+		$post    = get_post( $post_id );
+
+		// PostSitemapProvider の get_urls() は year/monthnum query var を使う
+		set_query_var( 'year', (int) date( 'Y', strtotime( $post->post_date ) ) );
+		set_query_var( 'monthnum', (int) date( 'm', strtotime( $post->post_date ) ) );
+		set_query_var( 'paged', 1 );
+
+		$provider = PostSitemapProvider::get_instance();
+
+		$xml = $this->render_url_items( $provider );
+		$sxe = $this->parse_sitemap_xml( $xml );
+
+		$found = false;
+		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
+			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
+			if ( empty( $lastmod ) ) {
+				continue;
+			}
+
+			// lastmod は post_date 以上であること
+			$post_date_ts = strtotime( $post->post_date );
+			$this->assertGreaterThanOrEqual(
+				$post_date_ts,
+				strtotime( $lastmod ),
+				"<lastmod>({$lastmod}) は post_date({$post->post_date}) 以上であること"
+			);
+			$found = true;
+		}
+
+		$this->assertTrue( $found, 'ポストサイトマップに URL が1件以上含まれること' );
+
+		delete_option( 'tsmap_post_types' );
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_news_sitemap_lastmod_correct_when_post_modified_is_newer() {
+		update_option( 'tsmap_news_post_types', [ 'post' ] );
+
+		// 通常投稿: post_modified > post_date (普通のケース)
+		$post_id = self::factory()->post->create( [
+			'post_status' => 'publish',
+			'post_title'  => 'Normal post',
+		] );
+
+		// post_modified を post_date より1時間後にする
+		global $wpdb;
+		$post    = get_post( $post_id );
+		$later   = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_date ) + 3600 );
+		$wpdb->update(
+			$wpdb->posts,
+			[
+				'post_modified'     => $later,
+				'post_modified_gmt' => get_gmt_from_date( $later ),
+			],
+			[ 'ID' => $post_id ]
+		);
+		clean_post_cache( $post_id );
+
+		$provider = NewsSitemapProvider::get_instance();
+		$xml      = $this->render_url_items( $provider );
+		$sxe      = $this->parse_sitemap_xml( $xml );
+
+		$found = false;
+		foreach ( $sxe->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' ) as $url ) {
+			$lastmod = (string) $url->children( 'http://www.sitemaps.org/schemas/sitemap/0.9' )->lastmod;
+			if ( empty( $lastmod ) ) {
+				continue;
+			}
+			// post_modified ベース (= $later) が使われていることを確認
+			$this->assertGreaterThanOrEqual(
+				strtotime( $post->post_date ),
+				strtotime( $lastmod ),
+				"<lastmod>({$lastmod}) は post_date({$post->post_date}) 以上であること"
+			);
+			$found = true;
+		}
+
+		$this->assertTrue( $found, 'ニュースサイトマップに URL が1件以上含まれること' );
+
+		delete_option( 'tsmap_news_post_types' );
+		wp_delete_post( $post_id, true );
+	}
+}

--- a/tests/SitemapLastmodTest.php
+++ b/tests/SitemapLastmodTest.php
@@ -103,8 +103,9 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 			'post_title'  => 'Scheduled post',
 		] );
 
-		$now = current_time( 'mysql' );
-		$old = date( 'Y-m-d H:i:s', strtotime( '-6 days', current_time( 'timestamp' ) ) );
+		$tz  = wp_timezone();
+		$now = ( new DateTimeImmutable( 'now', $tz ) )->format( 'Y-m-d H:i:s' );
+		$old = ( new DateTimeImmutable( '-6 days', $tz ) )->format( 'Y-m-d H:i:s' );
 
 		$updated = $wpdb->update(
 			$wpdb->posts,
@@ -220,7 +221,8 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 		// post_modified を post_date より1時間後にする
 		global $wpdb;
 		$post    = get_post( $post_id );
-		$later   = date( 'Y-m-d H:i:s', strtotime( $post->post_date ) + 3600 );
+		$later   = ( new DateTimeImmutable( $post->post_date, wp_timezone() ) )
+			->modify( '+1 hour' )->format( 'Y-m-d H:i:s' );
 		$updated = $wpdb->update(
 			$wpdb->posts,
 			[
@@ -249,12 +251,12 @@ class SitemapLastmodTest extends WP_UnitTestCase {
 			$this->assertNotEmpty( $lastmod, '<lastmod> が出力されていること' );
 
 			// post_modified ベース (= $later) が使われていることを確認
-			$post_date_ts = ( new DateTimeImmutable( $post->post_date, wp_timezone() ) )->getTimestamp();
-			$lastmod_ts   = ( new DateTimeImmutable( $lastmod ) )->getTimestamp();
-			$this->assertGreaterThanOrEqual(
-				$post_date_ts,
+			$later_ts   = ( new DateTimeImmutable( $later, wp_timezone() ) )->getTimestamp();
+			$lastmod_ts = ( new DateTimeImmutable( $lastmod ) )->getTimestamp();
+			$this->assertSame(
+				$later_ts,
 				$lastmod_ts,
-				"<lastmod>({$lastmod}) は post_date({$post->post_date}) 以上であること"
+				"<lastmod>({$lastmod}) は post_modified ({$later}) に一致すること"
 			);
 			$found = true;
 		}


### PR DESCRIPTION
## 変更内容
予約投稿が自動公開された際に、lastmodがpost_dateより古くなる問題を修正。lastmodの取得方法をpost_modifiedとpost_dateの最大値を使用するように変更し、関連するテストを追加。

## 関連イシュー・URL
#41

## 変更の種類
- [x] バグ修正
- [ ] 新機能
- [ ] 機能改善
- [ ] コードスタイルの更新（フォーマットの変更、空白の追加など）
- [ ] デザインやスタイルの調整
- [ ] リファクタリング（機能に影響しない変更）
- [ ] ドキュメントのみの変更
- [ ] パフォーマンスの改善
- [x] テストの追加・修正
- [ ] その他（詳細を記載）:

## テスト方法
1. 予約投稿を作成し、手動で公開する。
2. サイトマップを生成し、lastmodの値を確認する。
3. lastmodがpost_dateより古くないことを確認する。

## スクリーンショット
特になし

## 技術的詳細
特になし

## デプロイ後の作業
特になし

## チェックリスト
- [x] コードをローカルでテストした
- [ ] ドキュメントを更新した（必要な場合）
- [x] 変更に関連するテストを追加した（可能な場合）
- [ ] すべての依存関係が正しく解決されている

