### PR TITLE
オプションがnullを返す場合にエラーが発生しないように、オプションを配列としてキャストする変更を実装。

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": ""
+		"url": "git+https://github.com/tarosky/taro-sitemap.git"
 	},
 	"keywords": [],
 	"author": "Tarosky INC",

--- a/src/Tarosky/Sitemap/Seo/Features/CanonicalArchive.php
+++ b/src/Tarosky/Sitemap/Seo/Features/CanonicalArchive.php
@@ -28,7 +28,7 @@ class CanonicalArchive extends AbstractFeaturePattern {
 			return;
 		}
 		$canonical = '';
-		$options   = $this->option( 'canonical_archive' );
+		$options   = (array) $this->option( 'canonical_archive' );
 		$paged     = get_query_var( 'paged' );
 		$suffix    = 1 < $paged ? sprintf( 'page/%d', $paged ) : '';
 		if ( is_author() ) {

--- a/src/Tarosky/Sitemap/Seo/Features/OtherNoindex.php
+++ b/src/Tarosky/Sitemap/Seo/Features/OtherNoindex.php
@@ -26,7 +26,7 @@ class OtherNoindex extends RobotsFilterPattern {
 	public function wp_robots( $robots ) {
 		$noindex  = false;
 		$nofollow = false;
-		$options  = $this->option( 'noindex_other' );
+		$options  = (array) $this->option( 'noindex_other' );
 		if ( is_search() ) {
 			$noindex  = in_array( 'search', $options, true );
 			$nofollow = $noindex;

--- a/src/Tarosky/Sitemap/Seo/Features/PostSitemapExclusion.php
+++ b/src/Tarosky/Sitemap/Seo/Features/PostSitemapExclusion.php
@@ -23,7 +23,8 @@ class PostSitemapExclusion extends AbstractFeaturePattern {
 	}
 
 	public function is_active_post_type( $post_type ): bool {
-		return in_array( $post_type, $this->option( 'post_types' ), true );
+		$post_types = (array) $this->option( 'post_types' );
+		return in_array( $post_type, $post_types, true );
 	}
 
 	protected function do_save( $post ): void {

--- a/src/Tarosky/Sitemap/Seo/TermMetaBoxes.php
+++ b/src/Tarosky/Sitemap/Seo/TermMetaBoxes.php
@@ -88,7 +88,7 @@ class TermMetaBoxes extends Singleton {
 	 *
 	 * @param int    $term_id   Term ID.
 	 * @param int    $tt_id     Term taxonomy ID.
-	 * @param string $stasonomy taxonomy of this term.
+	 * @param string $taxonomy taxonomy of this term.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## 変更内容
オプションがnullを返す場合にエラーが発生しないように、オプションを配列としてキャストする変更を実装。

通常、Option が null になることは考えにくいですが、

1.管理画面上から zip の upload で taro-sitemap の アップグレード・ダウンロードを実施
2, その際、taro-sitemap-1 として別のプラグインとして install される場合がある。
3. taro-sitemap-1 を削除
4. taro-sitemap-1 側の uninstall hook が作動し、設定が delete_option で消される。
5. null を in_array で検査しようとしてエラーが発生。

というシナリオで発生しました。このプラグイン側に責務がある問題かは議論の余地がありそうですが、`Uncaught Error` が出る状況は好ましくないなということで。

## 関連イシュー・URL
#43

## 変更の種類
- [x] バグ修正
- [ ] 新機能
- [ ] 機能改善
- [ ] コードスタイルの更新（フォーマットの変更、空白の追加など）
- [ ] デザインやスタイルの調整
- [ ] リファクタリング（機能に影響しない変更）
- [ ] ドキュメントのみの変更
- [ ] パフォーマンスの改善
- [ ] テストの追加・修正
- [ ] その他（詳細を記載）:

## テスト方法
1. オプションがnullを返す状況を再現する。
2. エラーが発生しないことを確認する。
3. 他のオプションが正常に動作することを確認する。

## スクリーンショット
特になし

## 技術的詳細
特になし

## デプロイ後の作業
特になし

## チェックリスト
- [ ] コードをローカルでテストした
- [ ] ドキュメントを更新した（必要な場合）
- [ ] 変更に関連するテストを追加した（可能な場合）
- [ ] すべての依存関係が正しく解決されている

