### PR TITLE
Add watchtower notify caller workflow (#46)

### DIFF
--- a/.github/workflows/notify-watchtower.yml
+++ b/.github/workflows/notify-watchtower.yml
@@ -1,0 +1,21 @@
+# 外部パートナーが参加するリポにもそのまま置いてよい（シークレット・鍵はゼロ）。
+#
+# 動作:
+#   release が「リリース（prerelease ではない）」として publish されたら、
+#   tarosky/workflows の reusable workflow を呼び出して watchtower へ通知する。
+
+name: Notify watchtower on release
+
+on:
+  release:
+    types: [released]   # prerelease は除外。両方拾いたければ [released, prereleased] に変更
+
+jobs:
+  notify:
+    permissions:
+      id-token: write   # reusable 側ジョブの id-token: write はここから継承される
+      contents: read
+    uses: tarosky/workflows/.github/workflows/watchtower-notify.yml@main
+    # audience を上書きしたい場合のみ:
+    # with:
+    #   audience: watchtower


### PR DESCRIPTION
## 概要

closes #46

リリース時に [tarosky/watchtower](https://github.com/tarosky/watchtower) へ通知する caller workflow を `.github/workflows/notify-watchtower.yml` に配置しました。**Phase 1 パイロット**として taro-sitemap で先に検証します。

## 内容

- `release: { types: [released] }`（prerelease は除外）で発火
- `tarosky/workflows/.github/workflows/watchtower-notify.yml@main` を `uses` で呼び出し
- 呼び出し元ジョブに `permissions: id-token: write` / `contents: read` を付与（OIDC トークンを reusable 側へ継承）

## 鍵・シークレット

**不要**。GitHub の OIDC トークンを動的取得し、watchtower 側で署名検証＋ `repository_owner == tarosky` チェックを行うため、外部パートナーが参加するリポにもそのまま置けます。

## 動作確認

`release` イベントは手動 trigger できないため、以下のいずれかで確認します。

- A. 次の通常 release で確認（ナチュラル）
- B. テスト用 dummy release（`v0.0.0-watchtower-test` 等）を発行して watchtower 側 Slack `#support-sys` に通知が届くことを確認 → 確認後に削除/draft 化

動作確認が取れたら `taro-*` 他リポへ横展開（別 issue を起票）。

## 依存

- tarosky/workflows に reusable workflow `watchtower-notify.yml` が配置済み（main で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)