### PR TITLE
PHPのバージョンを8.1に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
 
       - name: Install Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.0
           tools: composer
 
       - name: Install Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           tools: composer
 
       - name: Install Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: PHP Syntax Check
     uses: tarosky/workflows/.github/workflows/phpcs.yml@main
     with:
-      version: 7.4
+      version: 8.1
 
   assets:
     name: Assets Test
@@ -40,6 +40,9 @@ jobs:
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.1, 8.2, 8.3]
     steps:
       - uses: actions/checkout@v4
 
@@ -54,7 +57,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: ${{ matrix.php-version }}
           tools: composer
 
       - name: Install Composer Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: PHP Syntax Check
     uses: tarosky/workflows/.github/workflows/phpcs.yml@main
     with:
-      version: 8.0
+      version: 8.1
 
   assets:
     name: Assets Test
@@ -36,13 +36,15 @@ jobs:
   short-open-tag:
     name: Short Open Tag Check
     uses: tarosky/workflows/.github/workflows/php-short-open-tag.yml@main
+    with:
+      version: '8.1'
 
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.0, 8.1, 8.3]
+        php-version: [8.1, 8.2, 8.3]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: PHP Syntax Check
     uses: tarosky/workflows/.github/workflows/phpcs.yml@main
     with:
-      version: 8.1
+      version: 8.0
 
   assets:
     name: Assets Test
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [8.0, 8.1, 8.3]
     steps:
       - uses: actions/checkout@v4
 

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"phpVersion": "7.4",
+	"phpVersion": "8.0",
 	"plugins": [
 		".",
 		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip",

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"phpVersion": "8.0",
+	"phpVersion": "8.1",
 	"plugins": [
 		".",
 		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip",

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Contributors: tarosky, Takahashi_Fumiki, tswallie  
 Tags: sitemap,google,news  
 Tested up to: 6.8  
+Requires PHP: 8.1  
 Stable Tag: nightly
 
 Sitemap plugin.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
     },
     "require": {
-        "php": "^7.4|^8"
+        "php": "^8.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
     },
     "require": {
-        "php": "^8.1"
+        "php": "^8.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
     },
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",

--- a/taro-sitemap.php
+++ b/taro-sitemap.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/taro-sitemap
 Description: Yet another sitemap plugin with more than 200,000 posts.
 Version: nightly
 Requires at least: 5.9
-Requires PHP: 8.0
+Requires PHP: 8.1
 Author: Tarosky INC
 Author URI: https://tarosky.co.jp
 Text Domain: tsmap

--- a/taro-sitemap.php
+++ b/taro-sitemap.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/taro-sitemap
 Description: Yet another sitemap plugin with more than 200,000 posts.
 Version: nightly
 Requires at least: 5.9
-Requires PHP: 7.4
+Requires PHP: 8.1
 Author: Tarosky INC
 Author URI: https://tarosky.co.jp
 Text Domain: tsmap

--- a/taro-sitemap.php
+++ b/taro-sitemap.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/taro-sitemap
 Description: Yet another sitemap plugin with more than 200,000 posts.
 Version: nightly
 Requires at least: 5.9
-Requires PHP: 8.1
+Requires PHP: 8.0
 Author: Tarosky INC
 Author URI: https://tarosky.co.jp
 Text Domain: tsmap


### PR DESCRIPTION
誤って rich-taxonomy ではなく、このプラグインの方で以下の issue の対応を進めていました。

* tarosky/rich-taxonomy#75

このアップデートに問題がなければ、こちらのプラグインもあわせて更新してしまってよいと思います。